### PR TITLE
[DNM] Split into packages that do and do not include models

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 62a157513a668bf8200932f59b1a5608c08371b63a4c8293ba46b2587385144b
 
 build:


### PR DESCRIPTION
This will require a new release to be useful, but I wanted to see if at the packaging level we have easy control over files which are included in each package. The goal as I understand it is to have two packages, moving forward
* `openff-nagl-models` includes all source code but **no model files**
  * This would make the package almost useless in its current state, but use https://github.com/openforcefield/openff-nagl-models/pull/44 in a new release
* `openff-nagl-models-all` depends on `openff-nagl-models` but somehow includes all of the model files it excludes

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
